### PR TITLE
Added failsafe _brushData assignment for double-click bug

### DIFF
--- a/d3.svg.circularbrush.js
+++ b/d3.svg.circularbrush.js
@@ -145,6 +145,9 @@ d3.svg.circularbrush = function() {
 	function resizeDown(d) {
 		var _mouse = d3.mouse(_brushG.node());
 
+		if (_brushData[0] === undefined) {
+			_brushData[0] = d;
+		}
 		_originalBrushData = {startAngle: _brushData[0].startAngle, endAngle: _brushData[0].endAngle};
 
 		_origin = _mouse;


### PR DESCRIPTION
Added failsafe _brushData assignment in resizeDown, in order to prevent a bug where double-clicking the circular brush before an initial drag would lock the brush.
emeeks: This library is incredibly useful and you rock for putting in all this work!
